### PR TITLE
Improve horizontal distance calculation with tests

### DIFF
--- a/py_code.py
+++ b/py_code.py
@@ -1,48 +1,116 @@
+"""Compute horizontal distance between two nodes at the same level in a binary tree.
+
+The distance counts the gaps where a node could have existed if the tree were
+complete.  For example, in the following tree the distance between the nodes
+``7`` and ``1`` is ``2`` because there would be a missing sibling between them::
+
+        5
+       / \
+      2   3
+     /   /
+    7   1
+
+The implementation performs a level‑order traversal while assigning a virtual
+position to every node as if the tree were a complete binary tree.  The
+distance between two nodes at the same level is the absolute difference of
+their positions.
+"""
+
+from __future__ import annotations
+
 from collections import deque
+from dataclasses import dataclass
+from typing import Optional
 
+
+@dataclass
 class TreeNode:
-    def __init__(self, x):
-        self.val = x
-        self.left = None
-        self.right = None
+    """Simple binary tree node used for tests and examples."""
 
-def findHorizontalDistance(root, node1, node2):
+    val: int
+    left: Optional["TreeNode"] = None
+    right: Optional["TreeNode"] = None
+
+
+def find_horizontal_distance(
+    root: Optional[TreeNode], node1: int, node2: int
+) -> int:
+    """Return the horizontal distance between ``node1`` and ``node2``.
+
+    Parameters
+    ----------
+    root:
+        The root of the binary tree.
+    node1, node2:
+        The values of the nodes whose distance is required.
+
+    Returns
+    -------
+    int
+        The horizontal distance if both nodes are present on the same level;
+        ``-1`` otherwise.
+
+    Notes
+    -----
+    The function assumes that node values are unique.  It short‑circuits once
+    the level containing the target nodes has been processed which makes it
+    more efficient than traversing the entire tree.
+    """
+
     if not root:
         return -1
 
-    # Queue for level order traversal, storing tuples of (node, level, horizontal distance)
-    q = deque([(root, 0, 0)])
-    node_distances = {}  # Dictionary to store the horizontal distance of each node
+    queue = deque([(root, 0)])  # (node, position)
 
-    while q:
-        node, level, hd = q.popleft()
-        if node:
-            # Store the horizontal distance for the node
-            node_distances[node.val] = (level, hd)
-            # Enqueue the left and right children with updated level and horizontal distance
-            q.append((node.left, level + 1, hd * 2))
-            q.append((node.right, level + 1, hd * 2 + 1))
+    while queue:
+        level_size = len(queue)
+        pos1 = pos2 = None
 
-    # Get the levels and horizontal distances of the target nodes
-    level1, hd1 = node_distances.get(node1, (-1, -1))
-    level2, hd2 = node_distances.get(node2, (-1, -1))
+        for _ in range(level_size):
+            node, pos = queue.popleft()
 
-    # If the nodes are at the same level, calculate the horizontal distance
-    if level1 == level2:
-        return abs(hd1 - hd2)
-    else:
-        return -1
+            if node.val == node1:
+                pos1 = pos
+            if node.val == node2:
+                pos2 = pos
 
-# Example Usage:
-root = TreeNode(5)
-root.left = TreeNode(2)
-root.right = TreeNode(3)
-root.left.left = TreeNode(7)
-root.right.left = TreeNode(1)
-root.right.left.left = TreeNode(4)
-root.right.left.right = TreeNode(6)
-root.left.left.left = TreeNode(9)
+            # enqueue children with their virtual positions
+            if node.left:
+                queue.append((node.left, pos * 2))
+            if node.right:
+                queue.append((node.right, pos * 2 + 1))
 
-print("For the nodes 9 and 4, the horizontal distance is:", findHorizontalDistance(root, 9, 4))
-print("For the nodes 7 and 1, the horizontal distance is:", findHorizontalDistance(root, 7, 1))
-print("For the nodes 9 and 6, the horizontal distance is:", findHorizontalDistance(root, 9, 6))
+        # Both nodes found on the same level
+        if pos1 is not None and pos2 is not None:
+            return abs(pos1 - pos2)
+
+        # If exactly one node is found at this level, they are on different levels
+        if (pos1 is not None) ^ (pos2 is not None):
+            return -1
+
+    return -1
+
+
+if __name__ == "__main__":  # pragma: no cover - example usage
+    root = TreeNode(5)
+    root.left = TreeNode(2)
+    root.right = TreeNode(3)
+    root.left.left = TreeNode(7)
+    root.right.left = TreeNode(1)
+    root.right.left.left = TreeNode(4)
+    root.right.left.right = TreeNode(6)
+    root.left.left.left = TreeNode(9)
+
+    print(
+        "For the nodes 9 and 4, the horizontal distance is:",
+        find_horizontal_distance(root, 9, 4),
+    )
+    print(
+        "For the nodes 7 and 1, the horizontal distance is:",
+        find_horizontal_distance(root, 7, 1),
+    )
+    print(
+        "For the nodes 9 and 6, the horizontal distance is:",
+        find_horizontal_distance(root, 9, 6),
+    )
+

--- a/tests/test_horizontal_distance.py
+++ b/tests/test_horizontal_distance.py
@@ -1,0 +1,46 @@
+"""Unit tests for the horizontal distance algorithm."""
+
+import os
+import sys
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from py_code import TreeNode, find_horizontal_distance
+
+
+def build_example_tree() -> TreeNode:
+    root = TreeNode(5)
+    root.left = TreeNode(2)
+    root.right = TreeNode(3)
+    root.left.left = TreeNode(7)
+    root.right.left = TreeNode(1)
+    root.right.left.left = TreeNode(4)
+    root.right.left.right = TreeNode(6)
+    root.left.left.left = TreeNode(9)
+    return root
+
+
+def test_example_distances():
+    root = build_example_tree()
+    assert find_horizontal_distance(root, 9, 4) == 4
+    assert find_horizontal_distance(root, 7, 1) == 2
+    assert find_horizontal_distance(root, 9, 6) == 5
+
+
+def test_nodes_on_different_levels():
+    root = build_example_tree()
+    assert find_horizontal_distance(root, 9, 1) == -1
+
+
+def test_missing_nodes():
+    root = build_example_tree()
+    # one node missing
+    assert find_horizontal_distance(root, 100, 4) == -1
+    # both nodes missing
+    assert find_horizontal_distance(root, 100, 101) == -1
+
+
+def test_empty_tree():
+    assert find_horizontal_distance(None, 1, 2) == -1
+


### PR DESCRIPTION
## Summary
- Replace prototype script with a robust `find_horizontal_distance` implementation
- Short-circuit traversal and return `-1` when nodes missing or on different levels
- Add unit tests covering example cases, missing nodes and empty tree

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f81a2c90832c949b476a0891e299